### PR TITLE
Fix benchmark of emulators

### DIFF
--- a/_posts/2023-08-02-gameroy-jit.md
+++ b/_posts/2023-08-02-gameroy-jit.md
@@ -597,6 +597,7 @@ not possible to disable it[^gambatte-options].
     configuration, but I modified the source code to disable that limit.
 
 Here are the results[^raw-data]:
+{: #emulator-comparison}
 
 [^raw-data]: You can also see the [raw data collected here](https://docs.google.com/spreadsheets/d/1jrf2O9iv1QbqRu0Hown5LX2dKIk7RecZ-SZrNFdJL7I/edit?usp=sharing).
 

--- a/assets/gameroy_jit/emulator-comparison.svg
+++ b/assets/gameroy_jit/emulator-comparison.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.64125pt" height="279.99625pt" viewBox="0 0 568.64125 279.99625" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.485937pt" height="279.99625pt" viewBox="0 0 568.485937 279.99625" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2023-08-26T18:06:45.481780</dc:date>
+    <dc:date>2023-09-10T14:25:26.318764</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -22,8 +22,8 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 279.99625 
-L 568.64125 279.99625 
-L 568.64125 0 
+L 568.485937 279.99625 
+L 568.485937 0 
 L 0 0 
 L 0 279.99625 
 z
@@ -31,125 +31,157 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 127.53125 242.44 
-L 561.44125 242.44 
-L 561.44125 7.2 
-L 127.53125 7.2 
-L 127.53125 242.44 
+    <path d="M 173.185937 242.44 
+L 561.285937 242.44 
+L 561.285937 7.2 
+L 173.185937 7.2 
+L 173.185937 242.44 
 z
 " style="fill: none"/>
    </g>
    <g id="patch_3">
-    <path d="M 127.53125 216.870435 
-L 191.632366 216.870435 
-L 191.632366 203.853202 
-L 127.53125 203.853202 
+    <path d="M 173.185937 220.709619 
+L 182.162761 220.709619 
+L 182.162761 211.051672 
+L 173.185937 211.051672 
 z
-" clip-path="url(#pa07ce7107c)" style="fill: #1f77b4"/>
+" clip-path="url(#p3cf292eb5f)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_4">
-    <path d="M 127.53125 179.67834 
-L 199.815487 179.67834 
-L 199.815487 166.661107 
-L 127.53125 166.661107 
+    <path d="M 173.185937 193.115484 
+L 186.713282 193.115484 
+L 186.713282 183.457537 
+L 173.185937 183.457537 
 z
-" clip-path="url(#pa07ce7107c)" style="fill: #1f77b4"/>
+" clip-path="url(#p3cf292eb5f)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_5">
-    <path d="M 127.53125 142.486245 
-L 254.369628 142.486245 
-L 254.369628 129.469012 
-L 127.53125 129.469012 
+    <path d="M 173.185937 165.521349 
+L 194.158083 165.521349 
+L 194.158083 155.863402 
+L 173.185937 155.863402 
 z
-" clip-path="url(#pa07ce7107c)" style="fill: #1f77b4"/>
+" clip-path="url(#p3cf292eb5f)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_6">
-    <path d="M 127.53125 105.29415 
-L 341.656254 105.29415 
-L 341.656254 92.276917 
-L 127.53125 92.276917 
+    <path d="M 173.185937 137.927214 
+L 203.408186 137.927214 
+L 203.408186 128.269267 
+L 173.185937 128.269267 
 z
-" clip-path="url(#pa07ce7107c)" style="fill: #1f77b4"/>
+" clip-path="url(#p3cf292eb5f)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_7">
-    <path d="M 127.53125 68.102055 
-L 535.323455 68.102055 
-L 535.323455 55.084822 
-L 127.53125 55.084822 
+    <path d="M 173.185937 110.333079 
+L 234.326055 110.333079 
+L 234.326055 100.675132 
+L 173.185937 100.675132 
 z
-" clip-path="url(#pa07ce7107c)" style="fill: #1f77b4"/>
+" clip-path="url(#p3cf292eb5f)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_8">
-    <path d="M 127.53125 30.90996 
-L 540.778869 30.90996 
-L 540.778869 17.892727 
-L 127.53125 17.892727 
+    <path d="M 173.185937 82.738944 
+L 218.330912 82.738944 
+L 218.330912 73.080997 
+L 173.185937 73.080997 
 z
-" clip-path="url(#pa07ce7107c)" style="fill: #1f77b4"/>
+" clip-path="url(#p3cf292eb5f)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_9">
-    <path d="M 127.53125 231.747273 
-L 190.268512 231.747273 
-L 190.268512 218.73004 
-L 127.53125 218.73004 
+    <path d="M 173.185937 55.144809 
+L 294.232273 55.144809 
+L 294.232273 45.486862 
+L 173.185937 45.486862 
 z
-" clip-path="url(#pa07ce7107c)" style="fill: #ff7f0e"/>
+" clip-path="url(#p3cf292eb5f)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_10">
-    <path d="M 127.53125 194.555178 
-L 239.367239 194.555178 
-L 239.367239 181.537945 
-L 127.53125 181.537945 
+    <path d="M 173.185937 27.550674 
+L 403.125944 27.550674 
+L 403.125944 17.892727 
+L 173.185937 17.892727 
 z
-" clip-path="url(#pa07ce7107c)" style="fill: #ff7f0e"/>
+" clip-path="url(#p3cf292eb5f)" style="fill: #1f77b4"/>
    </g>
    <g id="patch_11">
-    <path d="M 127.53125 157.363083 
-L 217.545583 157.363083 
-L 217.545583 144.34585 
-L 127.53125 144.34585 
+    <path d="M 173.185937 231.747273 
+L 190.435682 231.747273 
+L 190.435682 222.089326 
+L 173.185937 222.089326 
 z
-" clip-path="url(#pa07ce7107c)" style="fill: #ff7f0e"/>
+" clip-path="url(#p3cf292eb5f)" style="fill: #ff7f0e"/>
    </g>
    <g id="patch_12">
-    <path d="M 127.53125 120.170988 
-L 299.376795 120.170988 
-L 299.376795 107.153755 
-L 127.53125 107.153755 
+    <path d="M 173.185937 204.153138 
+L 209.900648 204.153138 
+L 209.900648 194.495191 
+L 173.185937 194.495191 
 z
-" clip-path="url(#pa07ce7107c)" style="fill: #ff7f0e"/>
+" clip-path="url(#p3cf292eb5f)" style="fill: #ff7f0e"/>
    </g>
    <g id="patch_13">
-    <path d="M 127.53125 82.978893 
-L 367.569471 82.978893 
-L 367.569471 69.96166 
-L 127.53125 69.96166 
+    <path d="M 173.185937 176.559003 
+L 255.165701 176.559003 
+L 255.165701 166.901056 
+L 173.185937 166.901056 
 z
-" clip-path="url(#pa07ce7107c)" style="fill: #ff7f0e"/>
+" clip-path="url(#p3cf292eb5f)" style="fill: #ff7f0e"/>
    </g>
    <g id="patch_14">
-    <path d="M 127.53125 45.786798 
-L 411.212784 45.786798 
-L 411.212784 32.769565 
-L 127.53125 32.769565 
+    <path d="M 173.185937 148.964868 
+L 281.255629 148.964868 
+L 281.255629 139.306921 
+L 173.185937 139.306921 
 z
-" clip-path="url(#pa07ce7107c)" style="fill: #ff7f0e"/>
+" clip-path="url(#p3cf292eb5f)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 173.185937 121.370733 
+L 276.568468 121.370733 
+L 276.568468 111.712786 
+L 173.185937 111.712786 
+z
+" clip-path="url(#p3cf292eb5f)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 173.185937 93.776598 
+L 272.564507 93.776598 
+L 272.564507 84.118651 
+L 173.185937 84.118651 
+z
+" clip-path="url(#p3cf292eb5f)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 173.185937 66.182463 
+L 454.75096 66.182463 
+L 454.75096 56.524516 
+L 173.185937 56.524516 
+z
+" clip-path="url(#p3cf292eb5f)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 173.185937 38.588328 
+L 542.804985 38.588328 
+L 542.804985 28.930381 
+L 173.185937 28.930381 
+z
+" clip-path="url(#p3cf292eb5f)" style="fill: #ff7f0e"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m0a46c451e8" d="M 0 0 
+       <path id="m8b03f3ee61" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0a46c451e8" x="127.53125" y="242.44" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b03f3ee61" x="173.185937" y="242.44" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 0 -->
-      <g transform="translate(124.35 257.038438) scale(0.1 -0.1)">
+      <g transform="translate(170.004687 257.038437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -180,12 +212,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m0a46c451e8" x="195.723926" y="242.44" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b03f3ee61" x="255.997962" y="242.44" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 5 -->
-      <g transform="translate(192.542676 257.038438) scale(0.1 -0.1)">
+      <g transform="translate(252.816712 257.038437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -220,12 +252,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m0a46c451e8" x="263.916603" y="242.44" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b03f3ee61" x="338.809986" y="242.44" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 10 -->
-      <g transform="translate(257.554103 257.038438) scale(0.1 -0.1)">
+      <g transform="translate(332.447486 257.038437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -250,12 +282,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m0a46c451e8" x="332.109279" y="242.44" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b03f3ee61" x="421.62201" y="242.44" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 15 -->
-      <g transform="translate(325.746779 257.038438) scale(0.1 -0.1)">
+      <g transform="translate(415.25951 257.038437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-35" x="63.623047"/>
       </g>
@@ -264,12 +296,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m0a46c451e8" x="400.301956" y="242.44" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b03f3ee61" x="504.434034" y="242.44" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 20 -->
-      <g transform="translate(393.939456 257.038438) scale(0.1 -0.1)">
+      <g transform="translate(498.071534 257.038437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -301,71 +333,9 @@ z
       </g>
      </g>
     </g>
-    <g id="xtick_6">
-     <g id="line2d_6">
-      <g>
-       <use xlink:href="#m0a46c451e8" x="468.494632" y="242.44" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_6">
-      <!-- 25 -->
-      <g transform="translate(462.132132 257.038438) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-32"/>
-       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_7">
-     <g id="line2d_7">
-      <g>
-       <use xlink:href="#m0a46c451e8" x="536.687308" y="242.44" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_7">
-      <!-- 30 -->
-      <g transform="translate(530.324808 257.038438) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-33"/>
-       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_8">
+    <g id="text_6">
      <!-- seconds -->
-     <g transform="translate(324.04875 270.716563) scale(0.1 -0.1)">
+     <g transform="translate(346.798437 270.716562) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-73" d="M 2834 3397 
 L 2834 2853 
@@ -523,20 +493,52 @@ z
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_8">
+     <g id="line2d_6">
       <defs>
-       <path id="mc88c4c962f" d="M 0 0 
+       <path id="m8a1ad5e6fc" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc88c4c962f" x="127.53125" y="217.800237" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a1ad5e6fc" x="173.185937" y="221.399472" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_9">
-      <!-- GameRoy (JIT) -->
-      <g transform="translate(49.235938 221.599456) scale(0.1 -0.1)">
+     <g id="text_7">
+      <!-- BGB (frameskip) -->
+      <g transform="translate(84.129687 225.198691) scale(0.1 -0.1)">
        <defs>
+        <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
         <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
 L 2778 1919 
@@ -560,6 +562,58 @@ Q 1025 1384 1454 906
 Q 1884 428 2741 428 
 Q 3075 428 3337 486 
 Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
 z
 " transform="scale(0.015625)"/>
         <path id="DejaVuSans-61" d="M 2194 1759 
@@ -625,34 +679,243 @@ Q 2666 3584 2933 3390
 Q 3200 3197 3328 2828 
 z
 " transform="scale(0.015625)"/>
-        <path id="DejaVuSans-52" d="M 2841 2188 
-Q 3044 2119 3236 1894 
-Q 3428 1669 3622 1275 
-L 4263 0 
-L 3584 0 
-L 2988 1197 
-Q 2756 1666 2539 1819 
-Q 2322 1972 1947 1972 
-L 1259 1972 
-L 1259 0 
-L 628 0 
-L 628 4666 
-L 2053 4666 
-Q 2853 4666 3247 4331 
-Q 3641 3997 3641 3322 
-Q 3641 2881 3436 2590 
-Q 3231 2300 2841 2188 
-z
-M 1259 4147 
-L 1259 2491 
-L 2053 2491 
-Q 2509 2491 2742 2702 
-Q 2975 2913 2975 3322 
-Q 2975 3731 2742 3939 
-Q 2509 4147 2053 4147 
-L 1259 4147 
+        <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
 z
 " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-42"/>
+       <use xlink:href="#DejaVuSans-47" x="66.853516"/>
+       <use xlink:href="#DejaVuSans-42" x="144.34375"/>
+       <use xlink:href="#DejaVuSans-20" x="212.947266"/>
+       <use xlink:href="#DejaVuSans-28" x="244.734375"/>
+       <use xlink:href="#DejaVuSans-66" x="283.748047"/>
+       <use xlink:href="#DejaVuSans-72" x="318.953125"/>
+       <use xlink:href="#DejaVuSans-61" x="360.066406"/>
+       <use xlink:href="#DejaVuSans-6d" x="421.345703"/>
+       <use xlink:href="#DejaVuSans-65" x="518.757812"/>
+       <use xlink:href="#DejaVuSans-73" x="580.28125"/>
+       <use xlink:href="#DejaVuSans-6b" x="632.380859"/>
+       <use xlink:href="#DejaVuSans-69" x="690.291016"/>
+       <use xlink:href="#DejaVuSans-70" x="718.074219"/>
+       <use xlink:href="#DejaVuSans-29" x="781.550781"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m8a1ad5e6fc" x="173.185937" y="193.805337" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- GambatteSpeedrun (frameskip) -->
+      <g transform="translate(7.2 197.604556) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-47"/>
+       <use xlink:href="#DejaVuSans-61" x="77.490234"/>
+       <use xlink:href="#DejaVuSans-6d" x="138.769531"/>
+       <use xlink:href="#DejaVuSans-62" x="236.181641"/>
+       <use xlink:href="#DejaVuSans-61" x="299.658203"/>
+       <use xlink:href="#DejaVuSans-74" x="360.9375"/>
+       <use xlink:href="#DejaVuSans-74" x="400.146484"/>
+       <use xlink:href="#DejaVuSans-65" x="439.355469"/>
+       <use xlink:href="#DejaVuSans-53" x="500.878906"/>
+       <use xlink:href="#DejaVuSans-70" x="564.355469"/>
+       <use xlink:href="#DejaVuSans-65" x="627.832031"/>
+       <use xlink:href="#DejaVuSans-65" x="689.355469"/>
+       <use xlink:href="#DejaVuSans-64" x="750.878906"/>
+       <use xlink:href="#DejaVuSans-72" x="814.355469"/>
+       <use xlink:href="#DejaVuSans-75" x="855.46875"/>
+       <use xlink:href="#DejaVuSans-6e" x="918.847656"/>
+       <use xlink:href="#DejaVuSans-20" x="982.226562"/>
+       <use xlink:href="#DejaVuSans-28" x="1014.013672"/>
+       <use xlink:href="#DejaVuSans-66" x="1053.027344"/>
+       <use xlink:href="#DejaVuSans-72" x="1088.232422"/>
+       <use xlink:href="#DejaVuSans-61" x="1129.345703"/>
+       <use xlink:href="#DejaVuSans-6d" x="1190.625"/>
+       <use xlink:href="#DejaVuSans-65" x="1288.037109"/>
+       <use xlink:href="#DejaVuSans-73" x="1349.560547"/>
+       <use xlink:href="#DejaVuSans-6b" x="1401.660156"/>
+       <use xlink:href="#DejaVuSans-69" x="1459.570312"/>
+       <use xlink:href="#DejaVuSans-70" x="1487.353516"/>
+       <use xlink:href="#DejaVuSans-29" x="1550.830078"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m8a1ad5e6fc" x="173.185937" y="166.211202" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- Gameroy JIT -->
+      <g transform="translate(105.30625 170.010421) scale(0.1 -0.1)">
+       <defs>
         <path id="DejaVuSans-79" d="M 2059 -325 
 Q 1816 -950 1584 -1140 
 Q 1353 -1331 966 -1331 
@@ -668,20 +931,6 @@ L 1894 763
 L 2988 3500 
 L 3597 3500 
 L 2059 -325 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-28" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
 z
 " transform="scale(0.015625)"/>
         <path id="DejaVuSans-4a" d="M 628 4666 
@@ -715,144 +964,55 @@ L -19 4134
 L -19 4666 
 z
 " transform="scale(0.015625)"/>
-        <path id="DejaVuSans-29" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
-z
-" transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-47"/>
        <use xlink:href="#DejaVuSans-61" x="77.490234"/>
        <use xlink:href="#DejaVuSans-6d" x="138.769531"/>
        <use xlink:href="#DejaVuSans-65" x="236.181641"/>
-       <use xlink:href="#DejaVuSans-52" x="297.705078"/>
-       <use xlink:href="#DejaVuSans-6f" x="362.6875"/>
-       <use xlink:href="#DejaVuSans-79" x="423.869141"/>
-       <use xlink:href="#DejaVuSans-20" x="483.048828"/>
-       <use xlink:href="#DejaVuSans-28" x="514.835938"/>
-       <use xlink:href="#DejaVuSans-4a" x="553.849609"/>
-       <use xlink:href="#DejaVuSans-49" x="583.341797"/>
-       <use xlink:href="#DejaVuSans-54" x="612.833984"/>
-       <use xlink:href="#DejaVuSans-29" x="673.917969"/>
+       <use xlink:href="#DejaVuSans-72" x="297.705078"/>
+       <use xlink:href="#DejaVuSans-6f" x="336.568359"/>
+       <use xlink:href="#DejaVuSans-79" x="397.75"/>
+       <use xlink:href="#DejaVuSans-20" x="456.929688"/>
+       <use xlink:href="#DejaVuSans-4a" x="488.716797"/>
+       <use xlink:href="#DejaVuSans-49" x="518.208984"/>
+       <use xlink:href="#DejaVuSans-54" x="547.701172"/>
       </g>
      </g>
     </g>
-    <g id="ytick_2">
+    <g id="ytick_4">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mc88c4c962f" x="127.53125" y="180.608142" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a1ad5e6fc" x="173.185937" y="138.617067" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
-      <!-- GameRoy (Interpreter) -->
-      <g transform="translate(7.2 184.407361) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-74" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-72" d="M 2631 2963 
-Q 2534 3019 2420 3045 
-Q 2306 3072 2169 3072 
-Q 1681 3072 1420 2755 
-Q 1159 2438 1159 1844 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1341 3275 1631 3429 
-Q 1922 3584 2338 3584 
-Q 2397 3584 2469 3576 
-Q 2541 3569 2628 3553 
-L 2631 2963 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-70" d="M 1159 525 
-L 1159 -1331 
-L 581 -1331 
-L 581 3500 
-L 1159 3500 
-L 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-z
-M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-" transform="scale(0.015625)"/>
-       </defs>
+      <!-- Gameroy Inter -->
+      <g transform="translate(93.842187 142.416286) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-47"/>
        <use xlink:href="#DejaVuSans-61" x="77.490234"/>
        <use xlink:href="#DejaVuSans-6d" x="138.769531"/>
        <use xlink:href="#DejaVuSans-65" x="236.181641"/>
-       <use xlink:href="#DejaVuSans-52" x="297.705078"/>
-       <use xlink:href="#DejaVuSans-6f" x="362.6875"/>
-       <use xlink:href="#DejaVuSans-79" x="423.869141"/>
-       <use xlink:href="#DejaVuSans-20" x="483.048828"/>
-       <use xlink:href="#DejaVuSans-28" x="514.835938"/>
-       <use xlink:href="#DejaVuSans-49" x="553.849609"/>
-       <use xlink:href="#DejaVuSans-6e" x="583.341797"/>
-       <use xlink:href="#DejaVuSans-74" x="646.720703"/>
-       <use xlink:href="#DejaVuSans-65" x="685.929688"/>
-       <use xlink:href="#DejaVuSans-72" x="747.453125"/>
-       <use xlink:href="#DejaVuSans-70" x="788.566406"/>
-       <use xlink:href="#DejaVuSans-72" x="852.042969"/>
-       <use xlink:href="#DejaVuSans-65" x="890.90625"/>
-       <use xlink:href="#DejaVuSans-74" x="952.429688"/>
-       <use xlink:href="#DejaVuSans-65" x="991.638672"/>
-       <use xlink:href="#DejaVuSans-72" x="1053.162109"/>
-       <use xlink:href="#DejaVuSans-29" x="1094.275391"/>
+       <use xlink:href="#DejaVuSans-72" x="297.705078"/>
+       <use xlink:href="#DejaVuSans-6f" x="336.568359"/>
+       <use xlink:href="#DejaVuSans-79" x="397.75"/>
+       <use xlink:href="#DejaVuSans-20" x="456.929688"/>
+       <use xlink:href="#DejaVuSans-49" x="488.716797"/>
+       <use xlink:href="#DejaVuSans-6e" x="518.208984"/>
+       <use xlink:href="#DejaVuSans-74" x="581.587891"/>
+       <use xlink:href="#DejaVuSans-65" x="620.796875"/>
+       <use xlink:href="#DejaVuSans-72" x="682.320312"/>
       </g>
      </g>
     </g>
-    <g id="ytick_3">
+    <g id="ytick_5">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc88c4c962f" x="127.53125" y="143.416047" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a1ad5e6fc" x="173.185937" y="111.022933" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- Emulicious -->
-      <g transform="translate(66.635938 147.215266) scale(0.1 -0.1)">
+      <g transform="translate(112.290625 114.822151) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-45" d="M 628 4666 
 L 3578 4666 
@@ -869,45 +1029,10 @@ L 628 0
 L 628 4666 
 z
 " transform="scale(0.015625)"/>
-        <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
-z
-" transform="scale(0.015625)"/>
         <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
 L 1178 0 
 L 603 0 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
-        <path id="DejaVuSans-69" d="M 603 3500 
-L 1178 3500 
-L 1178 0 
-L 603 0 
-L 603 3500 
-z
-M 603 4863 
-L 1178 4863 
-L 1178 4134 
-L 603 4134 
 L 603 4863 
 z
 " transform="scale(0.015625)"/>
@@ -925,64 +1050,30 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_4">
+    <g id="ytick_6">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mc88c4c962f" x="127.53125" y="106.223953" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a1ad5e6fc" x="173.185937" y="83.428798" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- BGB -->
-      <g transform="translate(99.235938 110.023171) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-42" d="M 1259 2228 
-L 1259 519 
-L 2272 519 
-Q 2781 519 3026 730 
-Q 3272 941 3272 1375 
-Q 3272 1813 3026 2020 
-Q 2781 2228 2272 2228 
-L 1259 2228 
-z
-M 1259 4147 
-L 1259 2741 
-L 2194 2741 
-Q 2656 2741 2882 2914 
-Q 3109 3088 3109 3444 
-Q 3109 3797 2882 3972 
-Q 2656 4147 2194 4147 
-L 1259 4147 
-z
-M 628 4666 
-L 2241 4666 
-Q 2963 4666 3353 4366 
-Q 3744 4066 3744 3513 
-Q 3744 3084 3544 2831 
-Q 3344 2578 2956 2516 
-Q 3422 2416 3680 2098 
-Q 3938 1781 3938 1306 
-Q 3938 681 3513 340 
-Q 3088 0 2303 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
+      <g transform="translate(144.890625 87.228016) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-42"/>
        <use xlink:href="#DejaVuSans-47" x="66.853516"/>
        <use xlink:href="#DejaVuSans-42" x="144.34375"/>
       </g>
      </g>
     </g>
-    <g id="ytick_5">
+    <g id="ytick_7">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc88c4c962f" x="127.53125" y="69.031858" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a1ad5e6fc" x="173.185937" y="55.834663" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- Beaten Dying Moon -->
-      <g transform="translate(22.335938 72.831076) scale(0.1 -0.1)">
+      <g transform="translate(67.990625 59.633882) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-44" d="M 1259 4147 
 L 1259 519 
@@ -1074,48 +1165,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_6">
+    <g id="ytick_8">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mc88c4c962f" x="127.53125" y="31.839763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a1ad5e6fc" x="173.185937" y="28.240528" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- SameBoy -->
-      <g transform="translate(73.2625 35.638982) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-53" d="M 3425 4513 
-L 3425 3897 
-Q 3066 4069 2747 4153 
-Q 2428 4238 2131 4238 
-Q 1616 4238 1336 4038 
-Q 1056 3838 1056 3469 
-Q 1056 3159 1242 3001 
-Q 1428 2844 1947 2747 
-L 2328 2669 
-Q 3034 2534 3370 2195 
-Q 3706 1856 3706 1288 
-Q 3706 609 3251 259 
-Q 2797 -91 1919 -91 
-Q 1588 -91 1214 -16 
-Q 841 59 441 206 
-L 441 856 
-Q 825 641 1194 531 
-Q 1563 422 1919 422 
-Q 2459 422 2753 634 
-Q 3047 847 3047 1241 
-Q 3047 1584 2836 1778 
-Q 2625 1972 2144 2069 
-L 1759 2144 
-Q 1053 2284 737 2584 
-Q 422 2884 422 3419 
-Q 422 4038 858 4394 
-Q 1294 4750 2059 4750 
-Q 2388 4750 2728 4690 
-Q 3069 4631 3425 4513 
-z
-" transform="scale(0.015625)"/>
-       </defs>
+      <g transform="translate(118.917187 32.039747) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-53"/>
        <use xlink:href="#DejaVuSans-61" x="63.476562"/>
        <use xlink:href="#DejaVuSans-6d" x="124.755859"/>
@@ -1127,79 +1185,51 @@ z
      </g>
     </g>
    </g>
-   <g id="patch_15">
-    <path d="M 127.53125 242.44 
-L 127.53125 7.2 
+   <g id="patch_19">
+    <path d="M 173.185937 242.44 
+L 173.185937 7.2 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_16">
-    <path d="M 561.44125 242.44 
-L 561.44125 7.2 
+   <g id="patch_20">
+    <path d="M 561.285937 242.44 
+L 561.285937 7.2 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_17">
-    <path d="M 127.53125 242.44 
-L 561.44125 242.44 
+   <g id="patch_21">
+    <path d="M 173.185937 242.44 
+L 561.285937 242.44 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_18">
-    <path d="M 127.53125 7.2 
-L 561.44125 7.2 
+   <g id="patch_22">
+    <path d="M 173.185937 7.2 
+L 561.285937 7.2 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
-    <g id="patch_19">
-     <path d="M 419.674062 237.44 
-L 554.44125 237.44 
-Q 556.44125 237.44 556.44125 235.44 
-L 556.44125 207.08375 
-Q 556.44125 205.08375 554.44125 205.08375 
-L 419.674062 205.08375 
-Q 417.674062 205.08375 417.674062 207.08375 
-L 417.674062 235.44 
-Q 417.674062 237.44 419.674062 237.44 
+    <g id="patch_23">
+     <path d="M 419.51875 237.44 
+L 554.285937 237.44 
+Q 556.285937 237.44 556.285937 235.44 
+L 556.285937 207.08375 
+Q 556.285937 205.08375 554.285937 205.08375 
+L 419.51875 205.08375 
+Q 417.51875 205.08375 417.51875 207.08375 
+L 417.51875 235.44 
+Q 417.51875 237.44 419.51875 237.44 
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="patch_20">
-     <path d="M 421.674062 216.682188 
-L 441.674062 216.682188 
-L 441.674062 209.682188 
-L 421.674062 209.682188 
+    <g id="patch_24">
+     <path d="M 421.51875 216.682187 
+L 441.51875 216.682187 
+L 441.51875 209.682187 
+L 421.51875 209.682187 
 z
 " style="fill: #1f77b4"/>
     </g>
     <g id="text_15">
      <!-- Tobu Tobu Girl -->
-     <g transform="translate(449.674062 216.682188) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-62" d="M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-M 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2969 
-z
-" transform="scale(0.015625)"/>
-      </defs>
+     <g transform="translate(449.51875 216.682187) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-54"/>
       <use xlink:href="#DejaVuSans-6f" x="44.083984"/>
       <use xlink:href="#DejaVuSans-62" x="105.265625"/>
@@ -1216,17 +1246,17 @@ z
       <use xlink:href="#DejaVuSans-6c" x="674.203125"/>
      </g>
     </g>
-    <g id="patch_21">
-     <path d="M 421.674062 231.360313 
-L 441.674062 231.360313 
-L 441.674062 224.360313 
-L 421.674062 224.360313 
+    <g id="patch_25">
+     <path d="M 421.51875 231.360312 
+L 441.51875 231.360312 
+L 441.51875 224.360312 
+L 421.51875 224.360312 
 z
 " style="fill: #ff7f0e"/>
     </g>
     <g id="text_16">
      <!-- The Legend of Zelda -->
-     <g transform="translate(449.674062 231.360313) scale(0.1 -0.1)">
+     <g transform="translate(449.51875 231.360312) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-68" d="M 3513 2113 
 L 3513 0 
@@ -1254,27 +1284,6 @@ L 3531 531
 L 3531 0 
 L 628 0 
 L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-66" d="M 2375 4863 
-L 2375 4384 
-L 1825 4384 
-Q 1516 4384 1395 4259 
-Q 1275 4134 1275 3809 
-L 1275 3500 
-L 2222 3500 
-L 2222 3053 
-L 1275 3053 
-L 1275 0 
-L 697 0 
-L 697 3053 
-L 147 3053 
-L 147 3500 
-L 697 3500 
-L 697 3744 
-Q 697 4328 969 4595 
-Q 1241 4863 1831 4863 
-L 2375 4863 
 z
 " transform="scale(0.015625)"/>
        <path id="DejaVuSans-5a" d="M 359 4666 
@@ -1316,8 +1325,8 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pa07ce7107c">
-   <rect x="127.53125" y="7.2" width="433.91" height="235.24"/>
+  <clipPath id="p3cf292eb5f">
+   <rect x="173.185937" y="7.2" width="388.1" height="235.24"/>
   </clipPath>
  </defs>
 </svg>


### PR DESCRIPTION
- Make BGB not be capped at 10x anymore.
- Include Gambatte.
- Include BGB with frameskip and without it.
- Expand the results analysis.
- Include errata about previous version.